### PR TITLE
feat: add VSI PathSpecificOptions and VSI Credentials

### DIFF
--- a/lib/ffi/cpl/vsi.rb
+++ b/lib/ffi/cpl/vsi.rb
@@ -111,6 +111,16 @@ module FFI
       attach_function :VSICTime, %i[ulong], :strptr
       attach_function :VSIGMTime, %i[pointer pointer], :pointer
       attach_function :VSILocalTime, %i[pointer pointer], :pointer
+
+      # GDAL 3.5+ VSI Credentials (legacy, VSI PathSpecificOptions should be used instead in GDAL 3.6+)
+      attach_function :VSISetCredential, %i[string string string], :void
+      attach_function :VSIClearCredentials, %i[string], :void
+      attach_function :VSIGetCredential, %i[string string string], :string
+
+      # GDAL 3.6+ VSI PathSpecificOptions
+      attach_function :VSISetPathSpecificOption, %i[string string string], :void
+      attach_function :VSIClearPathSpecificOptions, %i[string], :void
+      attach_function :VSIGetPathSpecificOption, %i[string string string], :string
     end
   end
 end

--- a/spec/ffi/cpl/vsi_spec.rb
+++ b/spec/ffi/cpl/vsi_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "gdal"
+
+RSpec.describe FFI::CPL::VSI do
+  if GDAL.version_num >= "3060000"
+    describe "VSI PathSpecificOptions" do
+      around do |example|
+        FFI::CPL::VSI.VSIClearPathSpecificOptions(nil)
+        example.run
+        FFI::CPL::VSI.VSIClearPathSpecificOptions(nil)
+      end
+
+      describe "VSIClearPathSpecificOptions" do
+        it "properly clears credentials" do
+          FFI::CPL::VSI.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
+          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+
+          FFI::CPL::VSI.VSIClearPathSpecificOptions(nil)
+          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be(nil)
+        end
+      end
+
+      describe "VSISetPathSpecificOption" do
+        it "properly sets credential" do
+          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be(nil)
+
+          FFI::CPL::VSI.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
+          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+        end
+      end
+
+      describe "VSIGetPathSpecificOption" do
+        it "properly get credential" do
+          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to be(nil)
+          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", "DefaultValue1234")).to eq("DefaultValue1234")
+
+          FFI::CPL::VSI.VSISetPathSpecificOption("/vsis3/test", "Key1234", "Value1234")
+
+          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+          expect(FFI::CPL::VSI.VSIGetPathSpecificOption("/vsis3/test", "Key1234", "DefaultValue1234")).to eq("Value1234")
+        end
+      end
+    end
+  end
+
+  if GDAL.version_num >= "3050000"
+    describe "VSI Credential" do
+      around do |example|
+        FFI::CPL::VSI.VSIClearCredentials(nil)
+        example.run
+        FFI::CPL::VSI.VSIClearCredentials(nil)
+      end
+
+      describe "VSIClearCredentials" do
+        it "properly clears credentials" do
+          FFI::CPL::VSI.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
+          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+
+          FFI::CPL::VSI.VSIClearCredentials(nil)
+          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be(nil)
+        end
+      end
+
+      describe "VSISetCredential" do
+        it "properly sets credential" do
+          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be(nil)
+
+          FFI::CPL::VSI.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
+          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+        end
+      end
+
+      describe "VSIGetCredential" do
+        it "properly get credential" do
+          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to be(nil)
+          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", "DefaultValue1234")).to eq("DefaultValue1234")
+
+          FFI::CPL::VSI.VSISetCredential("/vsis3/test", "Key1234", "Value1234")
+
+          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", nil)).to eq("Value1234")
+          expect(FFI::CPL::VSI.VSIGetCredential("/vsis3/test", "Key1234", "DefaultValue1234")).to eq("Value1234")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add FFI mappings for:
- VSISetPathSpecificOption
- VSIClearPathSpecificOptions
- VSIGetPathSpecificOption
- VSISetCredential
- VSIClearCredentials
- VSIGetCredential