### PR TITLE
ci: drop the retired ubuntu-20.04 runner from the test matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,10 +23,9 @@ jobs:
       fail-fast: false
       matrix:
         # NOTE:
-        # - ubuntu-20.04 has GDAL 3.0.4, PROJ 6.3.1, GEOS 3.8.0
         # - ubuntu-22.04 has GDAL 3.4.1, PROJ 8.2.1, GEOS 3.10.2
         # - ubuntu-24.04 has GDAL 3.8.4, PROJ 9.4.0, GEOS 3.12.1
-        os: ["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"]
+        os: ["ubuntu-22.04", "ubuntu-24.04"]
         ruby-version: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
     name: "Test on Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -70,8 +70,6 @@ CI is run against:
   (**GDAL 3.8.4**, PROJ 9.4.0, GEOS 3.12.1)
 - Ruby 2.6, 2.7, 3.0, 3.1, 3.2, 3.3 for Ubuntu 22.04
   (**GDAL 3.4.1**, PROJ 8.2.1, GEOS 3.10.2)
-- Ruby 2.6, 2.7, 3.0, 3.1, 3.2, 3.3 for Ubuntu 20.04
-  (**GDAL 3.0.4**, PROJ 6.3.1, GEOS 3.8.0)
 - Ruby 3.2 with **GDAL 2.4.4**
 
 > GDAL itself has differences in behaviour between versions. This means that


### PR DESCRIPTION
GitHub removed ubuntu-20.04 hosted runners, so those matrix lanes can no longer be scheduled. Remove the image from the CI matrix and from the README compatibility list (it was the GDAL 3.0.4 / PROJ 6.3.1 / GEOS 3.8.0 lane; the oldest remaining coverage is ubuntu-22.04 with GDAL 3.4.1, plus the GDAL 2.4 docker job).