### PR TITLE
fix: reset CPL error state when the error handler raises

### DIFF
--- a/lib/gdal/cpl_error_handler.rb
+++ b/lib/gdal/cpl_error_handler.rb
@@ -95,10 +95,13 @@ module GDAL
     # @return [Proc] A lambda that adheres to the CPL Error interface.
     def handler_lambda
       @handler_lambda ||= lambda do |error_class, error_number, message|
-        r = result(error_class, error_number, message)
+        result(error_class, error_number, message)
+      ensure
+        # Reset even when #result raises (CE_Failure/CE_Fatal): the exception
+        # already carries the error to Ruby-land, and a stale thread-local
+        # error state would be misread by OGR functions that report failure
+        # via CPLGetLastErrorType (e.g. OGR_DS_SyncToDisk).
         FFI::CPL::Error.CPLErrorReset
-
-        r
       end
     end
 

--- a/lib/ogr/data_source.rb
+++ b/lib/ogr/data_source.rb
@@ -236,7 +236,7 @@ module OGR
 
     # @raise [OGR::Failure]
     def sync_to_disk
-      OGR::ErrorHandling.handle_ogr_err("Unable to syn datasource to disk") do
+      OGR::ErrorHandling.handle_ogr_err("Unable to sync datasource to disk") do
         FFI::OGR::API.OGR_DS_SyncToDisk(@c_pointer)
       end
     end


### PR DESCRIPTION
OGR_DS_SyncToDisk (and similar OGR functions) report failure by inspecting the thread-local CPL error state via CPLGetLastErrorType, without resetting it first. Our CPL error handler intended to reset that state after handling every error, but on CE_Failure/CE_Fatal the FAIL_PROC raises before the reset line, leaking the error state.

Any later state-inspecting call then misread the stale error as its own failure, causing random order-dependent spec flakes such as:

  OGR::DataSource#sync_to_disk
    OGR::Failure: Unable to syn datasource to disk

Move the reset into an ensure block so it also runs when the handler raises, and fix the "syn" typo in the sync_to_disk failure message.